### PR TITLE
型周りのエラー解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ next-env.d.ts
 
 # vercel
 .vercel
+
+# yarn
+yarn-error.log

--- a/components/ContentBlocks.tsx
+++ b/components/ContentBlocks.tsx
@@ -1,3 +1,5 @@
+import Prism from 'prismjs'
+
 export const RenderBlocks = ({ blocks }) => {
   return blocks.map((block) => {
     const { type, id } = block
@@ -30,6 +32,18 @@ export const RenderBlocks = ({ blocks }) => {
       case 'numbered_list_item':
         return <ListItem key={id} value={value} id={id} />
 
+      case 'code':
+        return(
+        <code
+          dangerouslySetInnerHTML={{
+            __html:  Prism.highlight(
+              block.code.rich_text[0],
+              Prism.languages[block.code.language.toLowerCase()] ||
+                Prism.languages.javascript
+            ),
+          }}
+        />
+        )
       case 'to_do':
         return <ToDo key={id} value={value} />
 

--- a/lib/getNotionData.ts
+++ b/lib/getNotionData.ts
@@ -4,7 +4,7 @@ const notion = new Client({
   auth: process.env.NOTION_TOKEN,
 })
 
-export const getNotionData = async (databaseId) =>{
+export const getNotionData = async (databaseId:string) =>{
   const response = await notion.databases.query({
     database_id:databaseId,
     filter:{

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@notionhq/client": "^2.2.2",
     "framer-motion": "^7.6.7",
     "next": "^13.0.4",
+    "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@notionhq/client": "^2.2.2",
+    "@types/prismjs": "^1.26.0",
     "framer-motion": "^7.6.7",
     "next": "^13.0.4",
     "prismjs": "^1.29.0",

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -2,6 +2,7 @@ import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import React from "react";
 import { RenderBlocks } from "../components/ContentBlocks";
 import { getNotionData, getPage, getBlocks } from "../lib/getNotionData";
+import { Post } from "../types/notion";
 
 
 const databaseId = process.env.NOTION_DATABASE_ID;

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,12 +1,8 @@
-import { PageObjectResponse, PartialPageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
-import { GetStaticProps, GetStaticPropsContext } from "next";
+import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import React from "react";
 import { RenderBlocks } from "../components/ContentBlocks";
 import { getNotionData, getPage, getBlocks } from "../lib/getNotionData";
 
-//type Props = {posts:(PageObjectResponse | PartialPageObjectResponse)[]}
-type Props = {page:PageObjectResponse,blocks:any[]}
-type Params = {context:string}
 
 const databaseId = process.env.NOTION_DATABASE_ID;
 
@@ -22,8 +18,8 @@ export default function Post ({page, blocks}) {
   );
 };
 
-export const getStaticPaths = async () => {
-  const database = await getNotionData(databaseId);
+export const getStaticPaths:GetStaticPaths = async () => {
+  const database  = await getNotionData(databaseId) as Post[];
   return {
     paths: database.map((page) => ({
       params: {
@@ -35,9 +31,7 @@ export const getStaticPaths = async () => {
 };
 export const getStaticProps:GetStaticProps = async (context:GetStaticPropsContext) => {
   const { slug } = context.params;
-  console.log("context = ",context)
-  const database = await getNotionData(databaseId);
-  console.log("database = ",database)
+  const database = await getNotionData(databaseId) as Post[];
   const filter = database.filter(
     (blog) => blog.properties.Slug.rich_text[0].plain_text === slug
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import {
 import { getNotionData } from "../lib/getNotionData";
 import Link from "next/link";
 import { PageObjectResponse, PartialPageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import { Post } from "../types/notion";
 
 type Props = {posts:(PageObjectResponse | PartialPageObjectResponse)[]}
 type NotionPropsType = {posts:Post[]}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,6 @@ import {
   Card,
   CardBody,
   Container,
-  Flex,
   Stack,
   Text,
 } from "@chakra-ui/react";
@@ -13,20 +12,16 @@ import Link from "next/link";
 import { PageObjectResponse, PartialPageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 
 type Props = {posts:(PageObjectResponse | PartialPageObjectResponse)[]}
+type NotionPropsType = {posts:Post[]}
 
-const Home: NextPage<Props> = ({posts}) => {
-  // posts.map((post)=>{
-  //}
-  //const resultText = post.properties.Slug.rich_text[0].plain_text;
-  console.log("typeof = ",typeof posts[0].object)
-  //console.log("POSTS = ", posts);
+const Home: NextPage<NotionPropsType> = ({posts}) => {
   return (
     <Container marginY="16">
       <Text fontSize="3xl" backgroundColor="white" marginY="4">
         All
       </Text>
       {posts.map((post) => (
-        <Link href={`/${post.properties.Slug.rich_text[0].plain_text}`}>
+        <Link key={post.id} href={`/${post.properties.Slug.rich_text[0].plain_text}`}>
           <Card key={post.id} marginY="2">
             <CardBody>
               <Text fontSize="lg" fontWeight="bold">

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -1,0 +1,69 @@
+type TextType = {
+    annotations: {
+      bold: boolean;
+      code: boolean;
+      color: string;
+      italic: boolean;
+      strikethrough: boolean;
+      underline: boolean;
+    };
+    href: null;
+    plain_text: string;
+    text: { content: string; link: null };
+    type: string;
+}
+
+type TitleParamType = {
+  id:string,
+  title:TextType[],
+  type: string,
+}
+
+type TextParamType = {
+  id: string;
+  rich_text: TextType[];
+  type: string;
+};
+
+type DateParamType = {
+  date: { start: string; end: null; time_zone: null };
+  id: string;
+  type: string;
+};
+
+type CheckBoxParamType = {
+  checkbox: boolean,
+  id: string,
+  type: string,
+};
+
+type FileParamType = { files: string[]; id: string; type: string };
+
+type MultiSelectParamType = {
+  id:string,
+  multi_select:{color:string,id:string,name:string}[],
+  type:string,
+};
+
+export type Post = {
+  archived: boolean;
+  cover: null;
+  created_by: { id: string; object: string };
+  icon: null;
+  id: string;
+  last_edited_by: { object: string; id: string };
+  last_edited_time: string;
+  object: string;
+  parent: { type: string; database_id: string };
+  properties: {
+    "Cover Image":FileParamType ;
+    Date: DateParamType;
+    Description: TextParamType;
+    Post: TitleParamType, 
+    Published:CheckBoxParamType,
+    Slug: TextParamType,
+    Tag: MultiSelectParamType;
+  };
+  url:string,
+};
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,6 +1109,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prismjs@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.0.tgz#a1c3809b0ad61c62cac6d4e0c56d610c910b7654"
+  integrity sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==
+
 "@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,6 +1524,11 @@ prettier@2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
+prismjs@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
 prop-types@^15.6.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"


### PR DESCRIPTION
## Contents
getNotionDataで得られるデータの型は(PageObjectResponse | PartialPageObjectResponse)[]だが、
取得したデータを利用するときに後者のPartialPageObjectResponseが適用されて、propertiesが定義されてないと言われてしまう。かつ自分で決めた「Slug」などのパラメータは当然未定義なので、型アサーションで対応しても、Slugのところで未定義となる。そこで、自分で型を作成して本問題に対応した。
