### PR TITLE
refactor: prism theme and style

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,21 +7,18 @@
       "prismjs",
       {
         "languages": [
-          "typescript",
           "javascript",
-          "css",
           "html",
           "bash",
-          "yaml",
           "jsx",
-          "tsx",
           "json"
+      
         ],
         "plugins": [
           "line-numbers",
           "show-language"
         ],
-        "theme": "dark",
+        "theme": "okaidia",
         "css": true
       }
     ]

--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -17,7 +17,7 @@ const Code = ({ children, language }) => {
     Prism.highlightAll();
   }, []);
   return (
-      <Box overflow="auto" position="relative"  p="4" bgColor="gray" borderRadius="md">
+      //<Box overflow="auto" position="relative"  p="4" bgColor="gray" borderRadius="md">
        
       <pre>  
         <code
@@ -29,8 +29,25 @@ const Code = ({ children, language }) => {
           ),
         }}
       />
-      </pre>
-    </Box>
+      <style jsx>{`
+        code {
+          vertical-align: middle;
+          white-space: pre;
+          word-break: break-all;
+          max-width: 100%;
+          display: block;
+          font-size: 0.8rem;
+          line-height: 1.4;
+          padding: 1.25rem 1.5rem;
+          margin: 0.85rem 0;
+          background-color: #282c34;
+          color: #ccc;
+          border-radius: 6px;
+          overflow: auto;
+        }
+      `}</style>
+    </pre>
+    //</Box>
   );
 };
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,7 +5,7 @@ const Footer:React.FC = () => {
   return (
     <Box  bottom="0" py="16" textAlign="center">
       <Text fontSize="xs" fontWeight="thin">
-          © Copyright 2022 by onikun94.
+          © Copyright 2023 by onikun94.
       </Text>
     </Box>
   )


### PR DESCRIPTION
# 変更内容
Prism.jsのclassName指定は差分を生んでしまうことから利用できない。したがってスタイル属性を利用して、codeに対してcssスタイルを割り当てた。cssスタイルに関してはtsuburaya氏のスタイルを参考にした。
また.babelrcで指定したlanguagesは記述した順に優先順位が決まるっぽいので、適切な順番に変更した。